### PR TITLE
Consistency check: using /sdk/__ repeater topics in head

### DIFF
--- a/baxter/baxter_interface/src/baxter_interface/head.py
+++ b/baxter/baxter_interface/src/baxter_interface/head.py
@@ -20,7 +20,7 @@ class Head(object):
         self._state = {}
 
         self._pub_pan = rospy.Publisher(
-            '/robot/head/command_head_pan',
+            '/sdk/robot/head/command_head_pan',
             baxter_msgs.msg.HeadPanCommand)
 
         self._pub_nod = rospy.Publisher(
@@ -28,7 +28,7 @@ class Head(object):
             std_msgs.msg.Bool)
 
         self._sub_state = rospy.Subscriber(
-            '/robot/head/head_state',
+            '/sdk/robot/head/head_state',
             baxter_msgs.msg.HeadState,
             self._on_head_state)
 


### PR DESCRIPTION
Adds /sdk namespace topics (from translator) for HeadPanCommand and HeadState.

Note: HeadState 'isNodding' field doesn't seem to update in simulation (in standard or rsdk), so head wobbler example fails for me (in master and this branch).  This should work on the robot though.
