### PR TITLE
adding delay to fix head wobble example behavior

### DIFF
--- a/baxter/examples/head_control/src/wobbler.py
+++ b/baxter/examples/head_control/src/wobbler.py
@@ -70,6 +70,7 @@ class Wobbler():
         while (rospy.get_time() - start < 5.0):
             angle = random.uniform(-1.5, 1.5)
             self._head.set_pan(angle)
+            rate.sleep();
 
         #return to normal
         self.set_neutral()


### PR DESCRIPTION
head wobble example needed a delay between pan commands so it could actually have time to start moving towards target instead of just twitching.
