### PR TITLE
Generic init.sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -47,18 +47,18 @@ cat <<-EOF > ${tf}
 		source "\${HOME}"/.bash_profile
 	fi
 
-	eval release=${2}
-	if [ -z "\${release}" ]; then
+	eval version=${2}
+	if [ -z "\${version}" ]; then
 		auto=$(ls -1 /opt/ros | tail -n 1)
 		if [ -z "\${auto}" ]; then
 			echo "No ROS installation found in /opt/ros/"
 			exit 1
 		fi
 		ros_setup="/opt/ros/\${auto}"
-	elif [ "\${release:0:1}" == "/" ]; then
-		ros_setup="\${release}"
+	elif [ "\${version:0:1}" == "/" ]; then
+		ros_setup="\${version}"
 	else
-		ros_setup="/opt/ros/\${release}"
+		ros_setup="/opt/ros/\${version}"
 	fi
 
 	if [ ! -s "\${ros_setup}"/setup.sh ]; then


### PR DESCRIPTION
Modified init.sh script to handle any ROS release installed via source or Debian. 

Requires the ROS_ROOT environment variable to be set. This is assumed to be set on every shell instance due to the standard ROS installation step:
echo "source /opt/ros/version/setup.bash" >> ~/.bashrc
. ~/.bashrc

We should specify that this step is important in our ROS installation instructions.
