### PR TITLE
XBOX Joystick Remap Start Button to Function_2

### DIFF
--- a/baxter/utilities/src/iodevices/joystick.py
+++ b/baxter/utilities/src/iodevices/joystick.py
@@ -206,7 +206,7 @@ class XboxController(Joystick):
         self._controls['rightTrigger'] = (msg.axes[5] < 0.0)
 
         self._controls['function1'] = (msg.buttons[6] == 1)
-        self._controls['function2'] = (msg.buttons[10] == 1)
+        self._controls['function2'] = (msg.buttons[7] == 1)
 
 class LogitechController(Joystick):
     """ Logitech specialization of Joystick


### PR DESCRIPTION
Examples, tests, and mapping of Logitech controller describe the start button as 'function_2'. Currently button10 'right joystick press' is mapped to 'function_2' for the xbox controller.

This maps button7 'start' to 'function_2' for the xbox controller. Tested on Electric 10.04 and Groovy 12.04.
