### PR TITLE
Adding Parameters to DIO, AIO Ex's

### DIFF
--- a/baxter/examples/input_output/src/test_analog_io_rampup.py
+++ b/baxter/examples/input_output/src/test_analog_io_rampup.py
@@ -36,23 +36,29 @@ import baxter_interface.analog_io as AIO
 def test_interface(io_component = 'torso_fan'):
     """ Ramps an Analog component from 0 to 100, then back down to 0. """
     b = AIO.AnalogIO(io_component)
+    # start: 0.0
     print b.state()
-    # 0.0
+
+    # ramp up
     rate = rospy.Rate(2)
     for i in range(0,101,10):
         b.set_output(i)
         if i % 10 == 0: print i
         rate.sleep()
+    # max: 100.0
     print b.state()
-    # 100.0
+    
+    # ramp down
     for i in range(100,-1,-10):
         b.set_output(i)
         if i % 10 == 0: print i
         rate.sleep()
+    # (fans off)
     b.set_output(0)
-    #  (fans off)
 
 if __name__ == '__main__':
     rospy.init_node('test_aio', anonymous=True)
-    test_interface()
+    io_component = rospy.get_param('~component_id', 'torso_fan')
+    test_interface(io_component)
+
 

--- a/baxter/examples/input_output/src/test_digital_io_blink.py
+++ b/baxter/examples/input_output/src/test_digital_io_blink.py
@@ -36,17 +36,20 @@ import baxter_interface.digital_io as DIO
 def test_interface(io_component = 'left_itb_light_outer'):
     """ Blinks a Digital Output on then off. """
     b = DIO.DigitalIO(io_component)
-    print b.state()
-    # False
+    print("Blinking Digital Output: %s" % io_component)
+
+    print "Initial state: ", b.state()
+
+    # turn on light
     b.set_output(True)
-    #  (default: left arm navigator's outer light turns on)
     rospy.sleep(1)
-    print b.state()
-    # True
+    print "New state: ", b.state()
+
+    # reset output
     b.set_output(False)
-    #  (light out)
 
 if __name__ == '__main__':
     rospy.init_node('test_dio', anonymous=True)
-    test_interface()
+    io_component = rospy.get_param('~component_id', 'left_itb_light_outer')
+    test_interface(io_component)
 


### PR DESCRIPTION
This adds a (ROS) parameter argument to the digital / analog IO examples so that they can be called from the command line with different component ID's.  Ex:

`$ rosrun input_output test_digital_io_blink.py _component_id:=torso_left_itb_light_outer`

(Also, minorly cleans up some comments)
