### PR TITLE
Gripper Calibration and Enable

### DIFF
--- a/baxter/baxter_interface/src/baxter_interface/gripper.py
+++ b/baxter/baxter_interface/src/baxter_interface/gripper.py
@@ -110,7 +110,11 @@ class Gripper(object):
         Enable the gripper
         """
         self._pub_enable.publish(True)
-        dataflow.wait_for(lambda: self.enabled, timeout)
+        dataflow.wait_for(
+            test=self.enabled, 
+            timeout=timeout, 
+            body=lambda: self._pub_enable.publish(True)
+            )
 
     def disable(self):
         """
@@ -135,7 +139,11 @@ class Gripper(object):
         Calibrate the gripper
         """
         self._pub_calibrate.publish(stdmsg.Empty())
-        dataflow.wait_for(lambda: self.calibrated, timeout)
+        dataflow.wait_for(
+            test=self.calibrated, 
+            timeout=timeout, 
+            body=lambda: self._pub_calibrate.publish(stdmsg.Empty())
+            )
 
     def stop(self):
         """


### PR DESCRIPTION
Modifying gripper.calibrate and gripper.enable to be more consistent. 

Previously wait_for was returning without a timeout or without success. This behavior was observed on uncalibrated grippers.
