### PR TITLE
Printing joystick bindings at start of gripper_control

### DIFF
--- a/baxter/examples/gripper_control/src/joystick.py
+++ b/baxter/examples/gripper_control/src/joystick.py
@@ -91,6 +91,7 @@ def map_joystick(joystick):
     bindings_list.append(bindings)
 
     rate = rospy.Rate(100)
+    print_help(bindings_list)
     print("press any key to stop...")
     while not rospy.is_shutdown():
         if iodevices.getch():


### PR DESCRIPTION
Simple change to dump the joystick button bindings at the beginning of the gripper_control example -- replicates behavior of joint_position joystick example, and makes it easier to use.
