### PR TITLE
Add head.py standard timeouts. Improve movement robustness.

### DIFF
--- a/baxter/baxter_interface/src/baxter_interface/head.py
+++ b/baxter/baxter_interface/src/baxter_interface/head.py
@@ -61,7 +61,7 @@ class Head(object):
             self._on_head_state)
 
         dataflow.wait_for(
-            lambda: not len(self._state) == 0,
+            lambda: len(self._state) != 0,
             timeout=5.0,
             timeout_msg="Failed to get current head state from /sdk/robot/head/head_state",
         )


### PR DESCRIPTION
Adding dataflow.wait_for timeouts to initialization, set_pan and command_nod.

More robust state checking to verify execution for pan movements and head nods.
