### PR TITLE
Smoke Test Report Filename

### DIFF
--- a/baxter/tools/src/smoke_test/smoke_test.py
+++ b/baxter/tools/src/smoke_test/smoke_test.py
@@ -33,6 +33,7 @@ RSDK Smoke Test Execution
 import sys
 import time
 import argparse
+import re
 import socket
 import traceback
 
@@ -137,11 +138,15 @@ if __name__ == '__main__':
         print("\nExiting.")
         sys.exit(1)
 
+    master_hostname = re.split(
+        'http://|.local',
+        roslib.scriptutil.get_master().lookupNode('/rosnode', '/rosout')[2]
+        )[1]
     cur_time = time.localtime()
     filename = (
-                "rsdk-smoke_%s_%s.%s.%s" % \
-                (test_dict['version'], cur_time.tm_mday, cur_time.tm_mon, \
-                 cur_time.tm_year)
+                "%s-%s.%s.%s-rsdk-%s.smoketest" % \
+                (master_hostname, cur_time.tm_mon, cur_time.tm_mday, \
+                 cur_time.tm_year, test_dict['version'],)
                 )
     if args.test == None:
         print 'Performing All Tests'

--- a/baxter/tools/src/smoke_test/smoketests.py
+++ b/baxter/tools/src/smoke_test/smoketests.py
@@ -103,7 +103,10 @@ class SmokeTest(object):
         """
         self.result[0] = False
         self.result[1] = trace
-        self._rs.disable()
+        try:
+            self._rs.disable()
+        except:
+            pass
 
 class Enable(SmokeTest):
     """Verify ability to enable, check state and disable baxter.


### PR DESCRIPTION
Adding ros master hostname to the smoke test report filename. At ship this is set to the robot's serial number, making it useful for logging/documentation purposes.
