### PR TITLE
Smoke test hostname extraction across all distros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,12 @@ nosetests.xml
 cmake_install.cmake
 .pydevproject
 *.swp
+CATKIN_IGNORE
+catkin
+catkin_generated
+devel
+
+*.smoketest
 
 baxter/examples/joint-interface/baxter_joint_msgs/src/baxter_joint_msgs/msg/
 baxter/baxter_msgs/src/baxter_msgs/

--- a/baxter/tools/src/smoke_test/smoke_test.py
+++ b/baxter/tools/src/smoke_test/smoke_test.py
@@ -88,7 +88,7 @@ def get_version():
         rospy.get_param('/rethink/software_version').split('_')[0]
     except socket.error:
         print(
-            "Exiting: Could not communicate with ROS Master to determine" \
+            "Exiting: Could not communicate with ROS Master to determine " \
             "Software version"
             )
         sys.exit(1)
@@ -140,7 +140,7 @@ if __name__ == '__main__':
 
     master_hostname = re.split(
         'http://|.local',
-        roslib.scriptutil.get_master().lookupNode('/rosnode', '/rosout')[2]
+        rospy.get_master().getUri()[2]
         )[1]
     cur_time = time.localtime()
     filename = (

--- a/baxter/tools/src/smoke_test/smoketests.py
+++ b/baxter/tools/src/smoke_test/smoketests.py
@@ -252,9 +252,6 @@ class MoveArms(SmokeTest):
         try:
             print("Enabling robot...")
             self._rs.enable()
-            print("Moving Head to Neutral Location.")
-            head = baxter_interface.Head()
-            head.set_pan(0.0)
             print("Test: Create Limb Instances")
             right = baxter_interface.Limb('right')
             left = baxter_interface.Limb('left')


### PR DESCRIPTION
- Smoke test hostname extraction for file naming required distro specific calls. This has been fixed to use the higher level interface making it work across all distros.
- MoveArms smoke test no longer requires head movement.
- Add catkin generated files to gitignore.
