### PR TITLE
Tuning state rates down to 100Hz in all velocity exs.

### DIFF
--- a/baxter/examples/joint_velocity/src/puppet.py
+++ b/baxter/examples/joint_velocity/src/puppet.py
@@ -74,7 +74,7 @@ class Puppeteer(object):
 
         """
         self.set_neutral()
-        rate = rospy.Rate(1000);
+        rate = rospy.Rate(100);
         start = rospy.Time.now()
 
         control_joint_names = self._control_arm.joint_names()

--- a/baxter/examples/joint_velocity/src/wobbler.py
+++ b/baxter/examples/joint_velocity/src/wobbler.py
@@ -59,8 +59,8 @@ class Wobbler():
         self._left_joint_names = self._left_arm.joint_names()
         self._right_joint_names = self._right_arm.joint_names()
 
-        # set joint state publishing to 1000Hz
-        self._pub_rate.publish(1000)
+        # set joint state publishing to 100Hz
+        self._pub_rate.publish(100)
 
     def set_neutral(self):
         """
@@ -77,7 +77,7 @@ class Wobbler():
         Performs the wobbling of both arms
 
         """
-        rate = rospy.Rate(1000);
+        rate = rospy.Rate(100);
         start = rospy.Time.now()
 
         def make_v_func():
@@ -98,7 +98,7 @@ class Wobbler():
             if iodevices.getch():
                 done = True
             else:
-                self._pub_rate.publish(1000)
+                self._pub_rate.publish(100)
                 elapsed = rospy.Time.now() - start
                 cmd = dict(zip(self._left_joint_names, [v_funcs[i](elapsed) for i in range(len(self._left_joint_names))]))
                 self._left_arm.set_joint_velocities(cmd)


### PR DESCRIPTION
Temporarily tuning down the publish rate from 1000 Hz to 100 Hz in the velocity examples until the endpoint message is moved.

This is not tested yet on robot.
