### PR TITLE
two minor fixes for joint_trajectory; fixes trajectory_test.py issue

### DIFF
--- a/baxter/baxter_interface/src/joint_trajectory/joint_trajectory_action_server.py
+++ b/baxter/baxter_interface/src/joint_trajectory/joint_trajectory_action_server.py
@@ -89,7 +89,7 @@ class JointTrajectoryActionServer(object):
                 self._pid[joint].set_kp(self._parameters.config[joint + '_kp'])
                 self._pid[joint].set_ki(self._parameters.config[joint + '_ki'])
                 self._pid[joint].set_kd(self._parameters.config[joint + '_kd'])
-                self._goal_error[joint] = self._parameters.config[joint + '_kd']
+                self._goal_error[joint] = self._parameters.config[joint + '_goal']
                 self._error_threshold[joint] = self._parameters.config[joint + '_trajectory']
                 self._pid[joint].initialize()
             else:
@@ -175,7 +175,8 @@ class JointTrajectoryActionServer(object):
                 # If our current time is before the first specified point
                 # in the trajectory, then we should interpolate between
                 # our current position and that point.
-                p1 = self._get_current_position(joint_names)
+                p1 = JointTrajectoryPoint()
+                p1.positions = self._get_current_position(joint_names)
             else:
                 p1 = goal.trajectory.points[idx - 1]
 


### PR DESCRIPTION
Fixes blocking error about "missing time_from_start" with non-JointTrajectoryPoint start point when running trajectory_test.py. Fixes trac 7657
-  Uses a default JointTrajectoryPoint with p1.positions set, where there was just a list of positions stored to p1 directly before.
- Also, typo minor fix (I believe) in the parameters. @rethink-kmaroney should check me on this.
