### PR TITLE
Zero time_from_start bug, PEP8 cleanup 

### DIFF
--- a/baxter/baxter_interface/cfg/JointTrajectoryActionServer.cfg
+++ b/baxter/baxter_interface/cfg/JointTrajectoryActionServer.cfg
@@ -30,25 +30,43 @@
 import roslib
 roslib.load_manifest('baxter_interface')
 
-from dynamic_reconfigure.parameter_generator import *
+from dynamic_reconfigure.parameter_generator import (
+    ParameterGenerator,
+    double_t,
+)
 
 gen = ParameterGenerator()
 
-gen.add('goal_time', double_t, 0, "Amount of time (in seconds) that the \
-    controller is permitted to be late to the goal.", 0.0, 0.0)
-joints = ['left_s0', 'left_s1', 'left_e0', 'left_e1', 'left_w0', 'left_w1', \
-    'left_w2', 'right_s0', 'right_s1', 'right_e0', 'right_e1', 'right_w0', \
-    'right_w1', 'right_w2']
-for joint in joints:
-    gen.add(joint + '_goal', double_t, 0, "The maximum final error for " \
-    + joint, -1.0, -1.0, 3.0)
-    gen.add(joint + '_trajectory', double_t, 0, "The maximum error during \
-        trajectory execution for " + joint, -1.0, -1.0, 3.0)
-    gen.add(joint + '_kp', double_t, 0, joint + " proportional control gain", \
-        2.0, 0.0)
-    gen.add(joint + '_ki', double_t, 0, joint + " integral control gain", \
-        0.0, 0.0)
-    gen.add(joint + '_kd', double_t, 0, joint + " derivative control gain", \
-        0.0, 0.0)
+gen.add(
+    'goal_time', double_t, 0,
+    "Amount of time (s) controller is permitted to be late achieving goal",
+    0.0, 0.0
+    )
+
+joints = (
+    'left_s0', 'left_s1', 'left_e0', 'left_e1', 'left_w0', 'left_w1',
+    'left_w2', 'right_s0', 'right_s1', 'right_e0', 'right_e1', 'right_w0',
+    'right_w1', 'right_w2',
+    )
+
+params = ('_goal', '_trajectory', '_default_velocity', '_kp', '_ki', '_kd',)
+msg = (
+    " - maximum final error",
+    " - maximum error during trajectory execution",
+    " - default max velocity during trajectory execution",
+    " - Kp proportional control gain",
+    " - Ki integral control gain",
+    " - Kd derivative control gain",
+    )
+min = (-1.0, -1.0, 0.0, 0.0, 0.0, 0.0,)
+default = (-1.0, -1.0, 0.25, 2.0, 0.0, 0.0,)
+max = (3.0, 3.0, 2.5, 500.0, 100.0, 100.0,)
+
+for idx, param in enumerate(params):
+    for joint in joints:
+        gen.add(
+            joint + param, double_t, 0, joint + msg[idx],
+            default[idx], min[idx], max[idx]
+            )
 
 exit(gen.generate('baxter_interface', '', 'JointTrajectoryActionServer'))

--- a/baxter/baxter_interface/src/joint_trajectory/joint_trajectory_action_server.py
+++ b/baxter/baxter_interface/src/joint_trajectory/joint_trajectory_action_server.py
@@ -29,6 +29,7 @@
 Baxter RSDK Joint Trajectory Action Server
 """
 import math
+import operator
 import bisect
 
 import roslib
@@ -54,7 +55,7 @@ import baxter_interface
 
 class JointTrajectoryActionServer(object):
     def __init__(self, limb, parameters, rate=100.0):
-        self._parameters = parameters
+        self._param = parameters
         self._ns = '/sdk/robot/limb/' + limb + '/follow_joint_trajectory'
         self._server = actionlib.SimpleActionServer(
             self._ns,
@@ -72,6 +73,7 @@ class JointTrajectoryActionServer(object):
         self._goal_time = 0.0
         self._goal_error = {}
         self._error_threshold = {}
+        self._dflt_vel = {}
 
         # Create our PID controllers
         self._pid = {}
@@ -84,27 +86,30 @@ class JointTrajectoryActionServer(object):
         self._pub_rate.publish(self._control_rate)
 
     def _get_trajectory_parameters(self, joint_names):
-        for joint in joint_names:
-            if joint in self._limb.joint_names():
-                self._pid[joint].set_kp(self._parameters.config[joint + '_kp'])
-                self._pid[joint].set_ki(self._parameters.config[joint + '_ki'])
-                self._pid[joint].set_kd(self._parameters.config[joint + '_kd'])
-                self._goal_error[joint] = self._parameters.config[joint + '_goal']
-                self._error_threshold[joint] = self._parameters.config[joint + '_trajectory']
-                self._pid[joint].initialize()
-            else:
+        for jnt in joint_names:
+            if not jnt in self._limb.joint_names():
                 rospy.logerr(
                     "%s: Trajectory Aborted - Provided Invalid Joint Name %s" %
-                    (self._action_name, joint,))
+                    (self._action_name, jnt,))
                 self._server.set_aborted()
                 return False
+
+            self._pid[jnt].set_kp(self._param.config[jnt + '_kp'])
+            self._pid[jnt].set_ki(self._param.config[jnt + '_ki'])
+            self._pid[jnt].set_kd(self._param.config[jnt + '_kd'])
+            self._goal_error[jnt] = self._param.config[jnt + '_goal']
+            self._error_threshold[jnt] = self._param.config[jnt + '_trajectory']
+            self._dflt_vel[jnt] = self._param.config[jnt + '_default_velocity']
+            self._pid[jnt].initialize()
         return True
 
     def _get_current_position(self, joint_names):
         return [self._limb.joint_angle(joint) for joint in joint_names]
 
     def _get_current_error(self, joint_names, set_point):
-        return zip(joint_names, [(tgt - cur) for tgt, cur in zip(set_point, self._get_current_position(joint_names))])
+        current = self._get_current_position(joint_names)
+        error = map(operator.sub, set_point, current)
+        return zip(joint_names, error)
 
     def _command_stop(self, joint_names):
         velocities = [0.0] * len(joint_names)
@@ -123,7 +128,8 @@ class JointTrajectoryActionServer(object):
             if (delta[1] >= self._error_threshold[delta[0]]
                 and self._error_threshold[delta[0]] >= 0.0):
                 self._command_stop(joint_names)
-                rospy.logerr("%s: Trajectory Aborted - Exceeded Error Threshold on %s: %s" %
+                rospy.logerr(
+                             "%s: Exceeded Error Threshold on %s: %s" %
                              (self._action_name, delta[0], str(delta[1]),))
                 self._server.set_aborted()
                 return False
@@ -134,27 +140,46 @@ class JointTrajectoryActionServer(object):
         return True
 
     def _on_trajectory_action(self, goal):
-        # Load parameters for trajectory
         joint_names = goal.trajectory.joint_names
+        trajectory_points = goal.trajectory.points
+        # Load parameters for trajectory
         if not self._get_trajectory_parameters(joint_names):
+            self._server.set_aborted()
             return
 
         # Create a new discretized joint trajectory
-        num_points = len(goal.trajectory.points)
+        num_points = len(trajectory_points)
 
         if num_points == 0:
+            rospy.logerr("%s: Empty Trajectory" % (self._action_name,))
+            self._server.set_aborted()
             return
+
+        # If all time_from_start are zero,
+        # interject these based on default velocities
+        if all(pt.time_from_start.to_sec() == 0.0 for pt in trajectory_points):
+            last_point = self._get_current_position(joint_names)
+            move_time = 0.0
+            for point in trajectory_points:
+                diffs = map(operator.sub, point.positions,
+                            last_point)
+                diffs = map(operator.abs, diffs)
+                dflt_vel= [self._dflt_vel[jnt] for jnt in joint_names]
+                move_time = move_time + max(map(operator.div, diffs, dflt_vel))
+                point.time_from_start = rospy.Duration(move_time)
+                last_point = point.positions
 
         def interp(a, b, pct):
             return a + (b - a) * pct
 
         def interp_positions(p1, p2, pct):
-            return map(interp, p1.positions, p2.positions, [pct] * len(p1.positions))
+            return map(interp, p1.positions, p2.positions, [pct] *
+                       len(p1.positions))
 
-        end_time = goal.trajectory.points[-1].time_from_start.to_sec()
+        end_time = trajectory_points[-1].time_from_start.to_sec()
         control_rate = rospy.Rate(self._control_rate)
 
-        point_times = [point.time_from_start.to_sec() for point in goal.trajectory.points]
+        pnt_times = [pnt.time_from_start.to_sec() for pnt in trajectory_points]
 
          # Wait for the specified execution time, if not provided use now
         start_time = goal.trajectory.header.stamp.to_sec()
@@ -162,14 +187,14 @@ class JointTrajectoryActionServer(object):
             start_time = rospy.get_time()
         dataflow.wait_for(
             lambda: rospy.get_time() >= start_time,
-            timeout=float("inf")
+            timeout=float('inf')
         )
 
         # Loop until end of trajectory time.  Provide a single time step
         # of the control rate past the end to ensure we get to the end.
         now_from_start = rospy.get_time() - start_time
         while now_from_start < end_time + (1.0 / self._control_rate):
-            idx = bisect.bisect(point_times, now_from_start)
+            idx = bisect.bisect(pnt_times, now_from_start)
 
             if idx == 0:
                 # If our current time is before the first specified point
@@ -178,10 +203,10 @@ class JointTrajectoryActionServer(object):
                 p1 = JointTrajectoryPoint()
                 p1.positions = self._get_current_position(joint_names)
             else:
-                p1 = goal.trajectory.points[idx - 1]
+                p1 = trajectory_points[idx - 1]
 
             if idx != num_points:
-                p2 = goal.trajectory.points[idx]
+                p2 = trajectory_points[idx]
                 pct = ((now_from_start - p1.time_from_start.to_sec()) /
                        (p2.time_from_start - p1.time_from_start).to_sec())
                 point = interp_positions(p1, p2, pct)
@@ -198,11 +223,11 @@ class JointTrajectoryActionServer(object):
             now_from_start = rospy.get_time() - start_time
 
         # Keep trying to meet goal until goal_time constraint expired
-        last_point = goal.trajectory.points[-1].positions
-        last_time = goal.trajectory.points[-1].time_from_start.to_sec()
+        last_point = trajectory_points[-1].positions
+        last_time = trajectory_points[-1].time_from_start.to_sec()
         def check_goal_state():
             for error in self._get_current_error(joint_names, last_point):
-                if (self._goal_error[error[0]] > 0
+                if (self._goal_error[error[0]] > 0 
                     and self._goal_error[error[0]] < math.fabs(error[1])):
                     return error[0]
             else:
@@ -218,8 +243,8 @@ class JointTrajectoryActionServer(object):
         result = check_goal_state()
         if result != None:
             self._command_stop(goal.trajectory.joint_names)
-            rospy.logerr("%s: Trajectory Failed - %s \
-            Exceeded Goal Threshold Error" % (self._action_name, result,))
+            rospy.logerr("%s: Exceeded Goal Threshold Error %s" %
+                         (self._action_name, result,))
             self._server.set_aborted()
         else:
             self._command_stop(goal.trajectory.joint_names)

--- a/baxter/examples/joint_position/src/file_playback.py
+++ b/baxter/examples/joint_position/src/file_playback.py
@@ -126,7 +126,7 @@ def map_file(filename, loops=1):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("file", help="input file")
-    parser.add_argument("-l", "--loops", default=1, \
+    parser.add_argument("-l", "--loops", type=int, default=1, \
         help="number of times to loop the input file. 0=infinite.")
     args = parser.parse_args()
 
@@ -137,5 +137,4 @@ if __name__ == '__main__':
     print("Enabling robot... ")
     rs.enable()
 
-    map_file(args.file, int(args.loops))
-    rs.disable()
+    map_file(args.file, args.loops)


### PR DESCRIPTION
- Fixes case where no time_from_start values are specified by the joint trajectory action client. It now uses a new parameter, default_velocity, for each joint to determine the amount of time it will take to achieve each consecutive point. With the times specified the rest will be handled with the discretization in the joint_trajectory_action_server.
- General PEP8 compliance and cleanup, particularly line lengths.
