### PR TITLE
Enable robot (e-stop check) 7396

### DIFF
--- a/baxter_interface/src/baxter_interface/robustcontroller.py
+++ b/baxter_interface/src/baxter_interface/robustcontroller.py
@@ -135,7 +135,7 @@ class RobustController(object):
             elif self._return == errno.ETIMEDOUT:
                 raise IOError(self._return, "Robust controller timed out")
             elif self._return == errno.ECONNABORTED:
-                raise IOError(self._return, "Robust controller interruped by user")
+                raise IOError(self._return, "Robust controller interrupted by user")
             else:
                 raise IOError(self._return)
 


### PR DESCRIPTION
Enable Robot now checks for E-Stop Asserted before trying to enable.  Starts helping to distinguish between enable fails because of E-Stop, connection, or HW error.  Enable robot also now gives more verbose feedback (so user knows what it is doing).

Corresponds to trac: [http://www/trac/ticket/7396](http://www/trac/ticket/7396)
