### PR TITLE
Fix file playback looping and start

### DIFF
--- a/examples/joint_position/src/file_playback.py
+++ b/examples/joint_position/src/file_playback.py
@@ -135,7 +135,7 @@ def map_file(filename, loops=1):
                     grip_right.type() != 'custom'):
                     grip_right.command_position(cmd['right_gripper'])
                 rate.sleep()
-    print
+        print
     return True
 
 


### PR DESCRIPTION
Fixes start_time to be captured after the initial move_to_position
commands, and each time the playback loops.  (not sure how looping
ever worked before in joint_position...)
