### PR TITLE
Changing rosinstall URI's to HTTPS (no SSH keys)

### DIFF
--- a/baxter_sdk.rosinstall
+++ b/baxter_sdk.rosinstall
@@ -1,20 +1,20 @@
 - git:
     local-name: baxter
-    uri: git@github.com:RethinkRobotics/baxter.git
+    uri: https://github.com/RethinkRobotics/baxter.git
     version: master
 - git:
     local-name: baxter_interface
-    uri: git@github.com:RethinkRobotics/baxter_interface.git
+    uri: https://github.com/RethinkRobotics/baxter_interface.git
     version: master
 - git:
     local-name: baxter_tools
-    uri: git@github.com:RethinkRobotics/baxter_tools.git
+    uri: https://github.com/RethinkRobotics/baxter_tools.git
     version: master
 - git:
     local-name: baxter_common
-    uri: git@github.com:RethinkRobotics/baxter_common.git
+    uri: https://github.com/RethinkRobotics/baxter_common.git
     version: master
 - git:
     local-name: baxter_examples
-    uri: git@github.com:RethinkRobotics/baxter_examples.git
+    uri: https://github.com/RethinkRobotics/baxter_examples.git
     version: master


### PR DESCRIPTION
This change will allow users to use wstool to download and install
the Baxter SDK without having to setup SSH keys with Github.
- Note that users will still need to go through the ssh key setup
  process if they want to clone private repos, like the gazebo sim.
## 

Tested following wiki install instructions with modified file on dev station, I had previously not logged in to.

re: trac 9535
