### PR TITLE
Res #171 Use mktemp for cross-linux compatibility

### DIFF
--- a/baxter.sh
+++ b/baxter.sh
@@ -30,7 +30,7 @@ your_ip="192.168.XXX.XXX"
 ros_version="indigo"
 #-----------------------------------------------------------------------------#
 
-tf=$(tempfile)
+tf=$(mktemp)
 trap "rm -f -- '${tf}'" EXIT
 
 # If this file specifies an ip address or hostname - unset any previously set


### PR DESCRIPTION
Arch Linux, among other distributions, have depricated use of the `tempfile` command. To make the baxter.sh script useful for all distributions, this commit switches the `tempfile` command to the `mktemp` command from the `coreutils` package. The functionality for Debian users should remain unchanged.

Thanks to @alainsanguinetti for reporting this under Issue #171 